### PR TITLE
Create Custom Fixers

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MattAllan\LaravelCodeStyle;
 
+use MattAllan\LaravelCodeStyle\Fixers\LaravelPhpDocAlignFixer;
 use PhpCsFixer\ConfigInterface;
 
 class Config extends \PhpCsFixer\Config
@@ -58,6 +59,7 @@ class Config extends \PhpCsFixer\Config
             'indentation_type' => true,
             'integer_literal_case' => true,
             'braces' => false,
+            'LaravelCodeStyle/laravel_phpdoc_align' => true,
             'lowercase_cast' => true,
             'constant_case' => [
                 'case' => 'lower',
@@ -194,6 +196,10 @@ class Config extends \PhpCsFixer\Config
     public function __construct($name = 'Laravel')
     {
         parent::__construct($name);
+
+        $this->registerCustomFixers([
+            new LaravelPhpDocAlignFixer,
+        ]);
     }
 
     public function setRules(array $rules): ConfigInterface

--- a/src/Config.php
+++ b/src/Config.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MattAllan\LaravelCodeStyle;
 
-use MattAllan\LaravelCodeStyle\Fixers\LaravelPhpDocAlignFixer;
+use MattAllan\LaravelCodeStyle\Fixers\LaravelPhpdocAlignmentFixer;
 use PhpCsFixer\ConfigInterface;
 
 class Config extends \PhpCsFixer\Config
@@ -59,7 +59,7 @@ class Config extends \PhpCsFixer\Config
             'indentation_type' => true,
             'integer_literal_case' => true,
             'braces' => false,
-            'LaravelCodeStyle/laravel_phpdoc_align' => true,
+            'LaravelCodeStyle/laravel_phpdoc_alignment' => true,
             'lowercase_cast' => true,
             'constant_case' => [
                 'case' => 'lower',
@@ -198,7 +198,7 @@ class Config extends \PhpCsFixer\Config
         parent::__construct($name);
 
         $this->registerCustomFixers([
-            new LaravelPhpDocAlignFixer,
+            new LaravelPhpdocAlignmentFixer,
         ]);
     }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MattAllan\LaravelCodeStyle;
 
 use MattAllan\LaravelCodeStyle\Fixers\LaravelPhpdocAlignmentFixer;
+use MattAllan\LaravelCodeStyle\Fixers\LaravelPhpdocOrderFixer;
 use PhpCsFixer\ConfigInterface;
 
 class Config extends \PhpCsFixer\Config
@@ -60,6 +61,7 @@ class Config extends \PhpCsFixer\Config
             'integer_literal_case' => true,
             'braces' => false,
             'LaravelCodeStyle/laravel_phpdoc_alignment' => true,
+            'LaravelCodeStyle/laravel_phpdoc_order' => true,
             'lowercase_cast' => true,
             'constant_case' => [
                 'case' => 'lower',
@@ -198,6 +200,7 @@ class Config extends \PhpCsFixer\Config
         parent::__construct($name);
 
         $this->registerCustomFixers([
+            new LaravelPhpdocOrderFixer,
             new LaravelPhpdocAlignmentFixer,
         ]);
     }

--- a/src/Config.php
+++ b/src/Config.php
@@ -6,6 +6,7 @@ namespace MattAllan\LaravelCodeStyle;
 
 use MattAllan\LaravelCodeStyle\Fixers\LaravelPhpdocAlignmentFixer;
 use MattAllan\LaravelCodeStyle\Fixers\LaravelPhpdocOrderFixer;
+use MattAllan\LaravelCodeStyle\Fixers\LaravelPhpdocSeparationFixer;
 use PhpCsFixer\ConfigInterface;
 
 class Config extends \PhpCsFixer\Config
@@ -62,6 +63,7 @@ class Config extends \PhpCsFixer\Config
             'braces' => false,
             'LaravelCodeStyle/laravel_phpdoc_alignment' => true,
             'LaravelCodeStyle/laravel_phpdoc_order' => true,
+            'LaravelCodeStyle/laravel_phpdoc_separation' => true,
             'lowercase_cast' => true,
             'constant_case' => [
                 'case' => 'lower',
@@ -201,6 +203,7 @@ class Config extends \PhpCsFixer\Config
 
         $this->registerCustomFixers([
             new LaravelPhpdocOrderFixer,
+            new LaravelPhpdocSeparationFixer,
             new LaravelPhpdocAlignmentFixer,
         ]);
     }

--- a/src/Dev/GenerateRules.php
+++ b/src/Dev/GenerateRules.php
@@ -20,8 +20,6 @@ class GenerateRules
      * released version of PHP-CS-Fixer.
      */
     const UNRELEASED_RULES = [
-        // https://docs.styleci.io/fixers#laravel_phpdoc_separation
-        'laravel_phpdoc_separation',
         'phpdoc_singular_inheritdoc',
     ];
 
@@ -89,6 +87,9 @@ class GenerateRules
         ],
         'laravel_phpdoc_order' => [
             'LaravelCodeStyle/laravel_phpdoc_order' => true,
+        ],
+        'laravel_phpdoc_separation' => [
+            'LaravelCodeStyle/laravel_phpdoc_separation' => true,
         ],
         'lowercase_constants' => [
             'constant_case' => [

--- a/src/Dev/GenerateRules.php
+++ b/src/Dev/GenerateRules.php
@@ -87,7 +87,7 @@ class GenerateRules
             'braces' => false,
         ],
         'laravel_phpdoc_alignment' => [
-            'LaravelCodeStyle/laravel_phpdoc_align' => true,
+            'LaravelCodeStyle/laravel_phpdoc_alignment' => true,
         ],
         'lowercase_constants' => [
             'constant_case' => [

--- a/src/Dev/GenerateRules.php
+++ b/src/Dev/GenerateRules.php
@@ -20,8 +20,6 @@ class GenerateRules
      * released version of PHP-CS-Fixer.
      */
     const UNRELEASED_RULES = [
-        // https://docs.styleci.io/fixers#laravel_phpdoc_alignment
-        'laravel_phpdoc_alignment',
         // https://docs.styleci.io/fixers#laravel_phpdoc_order
         'laravel_phpdoc_order',
         // https://docs.styleci.io/fixers#laravel_phpdoc_separation
@@ -87,6 +85,9 @@ class GenerateRules
             // TODO: enable once braces fixers are split
             // See https://github.com/matt-allan/laravel-code-style/issues/47
             'braces' => false,
+        ],
+        'laravel_phpdoc_alignment' => [
+            'LaravelCodeStyle/laravel_phpdoc_align' => true,
         ],
         'lowercase_constants' => [
             'constant_case' => [

--- a/src/Dev/GenerateRules.php
+++ b/src/Dev/GenerateRules.php
@@ -20,8 +20,6 @@ class GenerateRules
      * released version of PHP-CS-Fixer.
      */
     const UNRELEASED_RULES = [
-        // https://docs.styleci.io/fixers#laravel_phpdoc_order
-        'laravel_phpdoc_order',
         // https://docs.styleci.io/fixers#laravel_phpdoc_separation
         'laravel_phpdoc_separation',
         'phpdoc_singular_inheritdoc',
@@ -88,6 +86,9 @@ class GenerateRules
         ],
         'laravel_phpdoc_alignment' => [
             'LaravelCodeStyle/laravel_phpdoc_alignment' => true,
+        ],
+        'laravel_phpdoc_order' => [
+            'LaravelCodeStyle/laravel_phpdoc_order' => true,
         ],
         'lowercase_constants' => [
             'constant_case' => [

--- a/src/Fixers/LaravelPhpDocAlignFixer.php
+++ b/src/Fixers/LaravelPhpDocAlignFixer.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace MattAllan\LaravelCodeStyle\Fixers;
+
+use PhpCsFixer\DocBlock\TypeExpression;
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use SplFileInfo;
+
+class LaravelPhpDocAlignFixer implements FixerInterface
+{
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isAnyTokenKindsFound([\T_DOC_COMMENT]);
+    }
+
+    public function isRisky(): bool
+    {
+        return false;
+    }
+
+    public function fix(SplFileInfo $file, Tokens $tokens): void
+    {
+        for ($index = $tokens->count() - 1; $index > 0; $index--) {
+            if (! $tokens[$index]->isGivenKind([\T_DOC_COMMENT])) {
+                continue;
+            }
+
+            $newContent = preg_replace_callback(
+                '/(?P<tag>@param)\s+(?P<hint>(?:'.TypeExpression::REGEX_TYPES.')?)\s+(?P<var>(?:&|\.{3})?\$\S+)/ux',
+                function ($matches) {
+                    return $matches['tag'].'  '.$matches['hint'].'  '.$matches['var'];
+                },
+                $tokens[$index]->getContent()
+            );
+
+            if ($newContent === $tokens[$index]->getContent()) {
+                continue;
+            }
+
+            $tokens[$index] = new Token([\T_DOC_COMMENT, $newContent]);
+        }
+    }
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition('After @param must be two spaces and after the Type Definition must also be two spaces.', [
+            new CodeSample('<?php
+/**
+ * @param string $foo
+ * @param  string  $bar
+ * @return string
+ */
+function a($foo, $bar) {}
+'),
+        ]);
+    }
+
+    public function getName(): string
+    {
+        return 'LaravelCodeStyle/laravel_phpdoc_align';
+    }
+
+    public function getPriority(): int
+    {
+        return -100;
+    }
+
+    public function supports(SplFileInfo $file): bool
+    {
+        return true;
+    }
+}

--- a/src/Fixers/LaravelPhpdocAlignmentFixer.php
+++ b/src/Fixers/LaravelPhpdocAlignmentFixer.php
@@ -11,18 +11,27 @@ use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use SplFileInfo;
 
-class LaravelPhpDocAlignFixer implements FixerInterface
+final class LaravelPhpdocAlignmentFixer implements FixerInterface
 {
+    /**
+     * {@inheritdoc}
+     */
     public function isCandidate(Tokens $tokens): bool
     {
         return $tokens->isAnyTokenKindsFound([\T_DOC_COMMENT]);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function isRisky(): bool
     {
         return false;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function fix(SplFileInfo $file, Tokens $tokens): void
     {
         for ($index = $tokens->count() - 1; $index > 0; $index--) {
@@ -46,6 +55,9 @@ class LaravelPhpDocAlignFixer implements FixerInterface
         }
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition('After @param must be two spaces and after the Type Definition must also be two spaces.', [
@@ -60,16 +72,25 @@ function a($foo, $bar) {}
         ]);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getName(): string
     {
-        return 'LaravelCodeStyle/laravel_phpdoc_align';
+        return 'LaravelCodeStyle/laravel_phpdoc_alignment';
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getPriority(): int
     {
         return -100;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function supports(SplFileInfo $file): bool
     {
         return true;

--- a/src/Fixers/LaravelPhpdocAlignmentFixer.php
+++ b/src/Fixers/LaravelPhpdocAlignmentFixer.php
@@ -85,7 +85,7 @@ function a($foo, $bar) {}
      */
     public function getPriority(): int
     {
-        return -100;
+        return -42;
     }
 
     /**

--- a/src/Fixers/LaravelPhpdocOrderFixer.php
+++ b/src/Fixers/LaravelPhpdocOrderFixer.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace MattAllan\LaravelCodeStyle\Fixers;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\DocBlock\DocBlock;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+final class LaravelPhpdocOrderFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return 'LaravelCodeStyle/laravel_phpdoc_order';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(T_DOC_COMMENT);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Annotations in PHPDoc should be ordered so that `@param` annotations come first, then `@return` annotations, then `@throws` annotations.',
+            [
+                new CodeSample(
+                    '<?php
+/**
+ * Hello there!
+ *
+ * @throws Exception|RuntimeException foo
+ * @custom Test!
+ * @return int  Return the number of changes.
+ * @param string $foo
+ * @param bool   $bar Bar
+ */
+'
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Must run before PhpdocAlignFixer, PhpdocSeparationFixer, PhpdocTrimFixer.
+     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocAddMissingParamAnnotationFixer, PhpdocIndentFixer, PhpdocNoEmptyReturnFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     */
+    public function getPriority(): int
+    {
+        return -2;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        foreach ($tokens as $index => $token) {
+            if (! $token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
+
+            $content = $token->getContent();
+            // move param to start, throws to end, leave return in the middle
+            $content = $this->moveParamAnnotations($content);
+            // we're parsing the content again to make sure the internal
+            // state of the docblock is correct after the modifications
+            $content = $this->moveThrowsAnnotations($content);
+            // persist the content at the end
+            $tokens[$index] = new Token([T_DOC_COMMENT, $content]);
+        }
+    }
+
+    /**
+     * Move all param annotations in before throws and return annotations.
+     */
+    private function moveParamAnnotations(string $content): string
+    {
+        $doc = new DocBlock($content);
+        $params = $doc->getAnnotationsOfType('param');
+
+        // nothing to do if there are no param annotations
+        if (0 === \count($params)) {
+            return $content;
+        }
+
+        $others = $doc->getAnnotationsOfType(['throws', 'return']);
+
+        if (0 === \count($others)) {
+            return $content;
+        }
+
+        // get the index of the final line of the final param annotation
+        $end = end($params)->getEnd();
+
+        $line = $doc->getLine($end);
+
+        // move stuff about if required
+        foreach ($others as $other) {
+            if ($other->getStart() < $end) {
+                // we're doing this to maintain the original line indices
+                $line->setContent($line->getContent().$other->getContent());
+                $other->remove();
+            }
+        }
+
+        return $doc->getContent();
+    }
+
+    /**
+     * Move all return annotations after param and throws annotations.
+     */
+    private function moveThrowsAnnotations(string $content): string
+    {
+        $doc = new DocBlock($content);
+        $throws = $doc->getAnnotationsOfType('throws');
+
+        // nothing to do if there are no return annotations
+        if (0 === \count($throws)) {
+            return $content;
+        }
+
+        $others = $doc->getAnnotationsOfType(['param', 'return']);
+
+        // nothing to do if there are no other annotations
+        if (0 === \count($others)) {
+            return $content;
+        }
+
+        // get the index of the first line of the first return annotation
+        $start = $throws[0]->getStart();
+        $line = $doc->getLine($start);
+
+        // move stuff about if required
+        foreach (array_reverse($others) as $other) {
+            if ($other->getEnd() > $start) {
+                // we're doing this to maintain the original line indices
+                $line->setContent($other->getContent().$line->getContent());
+                $other->remove();
+            }
+        }
+
+        return $doc->getContent();
+    }
+}

--- a/src/Fixers/LaravelPhpdocSeparationFixer.php
+++ b/src/Fixers/LaravelPhpdocSeparationFixer.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace MattAllan\LaravelCodeStyle\Fixers;
+
+use MattAllan\LaravelCodeStyle\Utils\PhpdocTagComperator;
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\DocBlock\Annotation;
+use PhpCsFixer\DocBlock\DocBlock;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+final class LaravelPhpdocSeparationFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return 'LaravelCodeStyle/laravel_phpdoc_separation';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Annotations in PHPDoc should be grouped together so that annotations of the same type immediately follow each other, and annotations of a different type are separated by a single blank line. @param and @return are of the same type',
+            [
+                new CodeSample(
+                    '<?php
+/**
+ * Description.
+ * @param string $foo
+ *
+ *
+ * @param bool   $bar Bar
+ * @throws Exception|RuntimeException
+ * @return bool
+ */
+function fnc($foo, $bar) {}
+'
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Must run before PhpdocAlignFixer.
+     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, GeneralPhpdocAnnotationRemoveFixer, PhpdocIndentFixer, PhpdocNoAccessFixer, PhpdocNoEmptyReturnFixer, PhpdocNoPackageFixer, PhpdocOrderFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     */
+    public function getPriority(): int
+    {
+        return -3;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(T_DOC_COMMENT);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        foreach ($tokens as $index => $token) {
+            if (! $token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
+
+            $doc = new DocBlock($token->getContent());
+            $this->fixDescription($doc);
+            $this->fixAnnotations($doc);
+
+            $tokens[$index] = new Token([T_DOC_COMMENT, $doc->getContent()]);
+        }
+    }
+
+    /**
+     * Make sure the description is separated from the annotations.
+     */
+    private function fixDescription(DocBlock $doc): void
+    {
+        foreach ($doc->getLines() as $index => $line) {
+            if ($line->containsATag()) {
+                break;
+            }
+
+            if ($line->containsUsefulContent()) {
+                $next = $doc->getLine($index + 1);
+
+                if (null !== $next && $next->containsATag()) {
+                    $line->addBlank();
+
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * Make sure the annotations are correctly separated.
+     */
+    private function fixAnnotations(DocBlock $doc): void
+    {
+        foreach ($doc->getAnnotations() as $index => $annotation) {
+            $next = $doc->getAnnotation($index + 1);
+
+            if (null === $next) {
+                break;
+            }
+
+            if (true === $next->getTag()->valid()) {
+                if (PhpdocTagComperator::shouldBeTogether($annotation->getTag(), $next->getTag())) {
+                    $this->ensureAreTogether($doc, $annotation, $next);
+                } else {
+                    $this->ensureAreSeparate($doc, $annotation, $next);
+                }
+            }
+        }
+    }
+
+    /**
+     * Force the given annotations to immediately follow each other.
+     */
+    private function ensureAreTogether(DocBlock $doc, Annotation $first, Annotation $second): void
+    {
+        $pos = $first->getEnd();
+        $final = $second->getStart();
+
+        for ($pos = $pos + 1; $pos < $final; $pos++) {
+            $doc->getLine($pos)->remove();
+        }
+    }
+
+    /**
+     * Force the given annotations to have one empty line between each other.
+     */
+    private function ensureAreSeparate(DocBlock $doc, Annotation $first, Annotation $second): void
+    {
+        $pos = $first->getEnd();
+        $final = $second->getStart() - 1;
+
+        // check if we need to add a line, or need to remove one or more lines
+        if ($pos === $final) {
+            $doc->getLine($pos)->addBlank();
+
+            return;
+        }
+
+        for ($pos = $pos + 1; $pos < $final; $pos++) {
+            $doc->getLine($pos)->remove();
+        }
+    }
+}

--- a/src/Utils/PhpdocTagComperator.php
+++ b/src/Utils/PhpdocTagComperator.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace MattAllan\LaravelCodeStyle\Utils;
+
+use PhpCsFixer\DocBlock\Tag;
+
+final class PhpdocTagComperator
+{
+    /**
+     * Groups of tags that should be allowed to immediately follow each other.
+     *
+     * @var array
+     */
+    private static $groups = [
+        ['deprecated', 'link', 'see', 'since'],
+        ['author', 'copyright', 'license'],
+        ['category', 'package', 'subpackage'],
+        ['property', 'property-read', 'property-write'],
+        ['param', 'return'],
+    ];
+
+    /**
+     * Should the given tags be kept together, or kept apart?
+     */
+    public static function shouldBeTogether(Tag $first, Tag $second): bool
+    {
+        $firstName = $first->getName();
+        $secondName = $second->getName();
+
+        if ($firstName === $secondName) {
+            return true;
+        }
+
+        foreach (self::$groups as $group) {
+            if (\in_array($firstName, $group, true) && \in_array($secondName, $group, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Currently there are some missing Fixers for the Laravel Code Style which are used by StyleCI.

These are:
- [x] `laravel_phpdoc_alignment`
- [x] `laravel_phpdoc_order`
- [x] `laravel_phpdoc_seperation`

Examples what each rule does:

### `laravel_phpdoc_alignment`
After `@param` should be two spaces then a `type-hint` then another two spaces and then the `$variable`
```diff
  /**
   * Here is a description for what the function does
-  * @param string $foo
+  * @param  string  $foo
   * @return string
   */
  public function bar($foo) {}
```

### `laravel_phpdoc_order`
First should be the `description` after that `@param` then `@return` and at last `@throws`
The default rule `phpdoc_order` has a different order: `description`, `@param`, `@throws`, `@return`
```diff
  /**
   * Here is a description for what the function does
   * @param string $foo
   * @param  string  $foo
-  * @throws \Exception
   * @return string
+  * @throws \Exception
   */
  public function bar($foo) {}
```

### `laravel_phpdoc_seperation `
Between each group of tags should be an empty line for seperation. `@param` and `@return` are always of the same group and are not to be seperated with an empty line.
The default behaviour for `phpdoc_seperation` is also an empty line between `@param` and `@return`.
```diff
  /**
   * Here is a description for what the function does
+  *
   * @param string $foo
   * @param  string  $foo
-  *
   * @return string
+  *
   * @throws \Exception
   */
  public function bar($foo) {}
```