### PR TITLE
Don't format blade files in any of folders

### DIFF
--- a/config/.php-cs-fixer.dist.php
+++ b/config/.php-cs-fixer.dist.php
@@ -6,6 +6,7 @@ require __DIR__.'/bootstrap/app.php';
 return (new Jubeki\LaravelCodeStyle\Config())
     ->setFinder(
         PhpCsFixer\Finder::create()
+            ->notName('*.blade.php')
             ->in(app_path())
             ->in(config_path())
             ->in(database_path('factories'))


### PR DESCRIPTION
Hi,

There are very less chance that a developer will store the blade files in the configured folders, but there is no harm to exclude all blade files from checking since php-cs-fixer can not fix blade files .

